### PR TITLE
Http get request fixed

### DIFF
--- a/Analytics/GoogleAnalyticsManager.cs
+++ b/Analytics/GoogleAnalyticsManager.cs
@@ -114,6 +114,7 @@ namespace LeopotamGroup.Analytics {
 #endif
 
                     using (var req = UnityWebRequest.Get (url)) {
+                        req.SetRequestHeader("user-agent", "Mozilla/5.0");
                         yield return req.SendWebRequest ();
                     }
                     url = null;

--- a/Analytics/GoogleAnalyticsManager.cs
+++ b/Analytics/GoogleAnalyticsManager.cs
@@ -114,7 +114,7 @@ namespace LeopotamGroup.Analytics {
 #endif
 
                     using (var req = UnityWebRequest.Get (url)) {
-                        req.SetRequestHeader("user-agent", "Mozilla/5.0");
+                        req.SetRequestHeader("user-agent", "");
                         yield return req.SendWebRequest ();
                     }
                     url = null;


### PR DESCRIPTION
Знаю, что репо легаси, но эта хрень отняла у меня весь вечер

Вкратце баг:
Google analytics игнорирует get запросы, если в хедере user-agent присутствует слово unity, как-то так